### PR TITLE
Describe arena combat protocol in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ that we test out the front-back communication
 | - | - |
 | `request_map_info` 1 | `EMPTY_PAYLOAD` |
 | `try_move` 1 | `{ direction: DIRECTION }` |
+| `try_attack` 1 | `{ targetId: int }` |
 | `try_leave` 1 | `EMPTY_PAYLOAD ` |
 
 # Server emitted messages
@@ -26,6 +27,7 @@ that we test out the front-back communication
 | `goto` 1 | `{ where: MAP }` |`
 | `map_info` 1 | `{ pawns: [CHARACTER_PAWN] }` |`
 | `move` * | `{ characterId: int, from: BOARD_COORDINATE, to: BOARD_COORDINATE }` |`
+| `attack` * | `{ aggressorId: int, targetId: int, type: HIT_TYPE, damage: float }` |`
 | `leave` * | `{ characterId: int }` |`
 
 # Type definitions
@@ -34,4 +36,15 @@ that we test out the front-back communication
 - `DIRECTION := "N" | "E" | "S" | "W"`
 - `BOARD_COORDINATE := { x: int, y: int }`
 - `CHARACTER_PAWN :=
-  { id: int, location: BOARD_COORDINATE, front: DIRECTION, color: int }`
+  { id: int, location: BOARD_COORDINATE, front: DIRECTION, color: int, baseStats: STATS }`
+- ```js
+  STATS := {
+    health: float,
+    damage: float,
+    range: [BOARD_COORDINATE],
+    evasionRate:  float[0, 1],
+    criticalRate: float[0, 1],
+    criticalMultiplier: float,
+  }
+```
+- `HIT_TYPE := "hit" | "miss" | "critical"`


### PR DESCRIPTION
Adds on the current protocol the ability to combat between players.
The flow of an attack would go as follows:
1. User touches target character which sends try_attack
2. Server checks that target character is in range and if so calculates `damage` and hit `type`.
  2.1. Roll dice with aggressor `criticalRate` chances, if favoured, make `type = "critical"` and `damage = aggressor.damage * criticalMultiplier`
  2.2. Roll dice with target `evasionRate`, if favoured, make `type = "miss"` and `damage = 0`
  2.3. If no roll favours, then `type = "hit"` and `damage = aggressor.damage`
  2.4. Decrease target's health
3. Broadcast `attack` response

Another thing to clarify is that range is a description of "local" board coordinates, i.e. [{ x: 0, y: 1 }] would mean that I can attack only one cell in front of the character having into account its current position and orientation, (can be done with a matrix multiplication with the proper base vectors).